### PR TITLE
Enables module loading from files/module_name in local Jade server.py

### DIFF
--- a/server.py
+++ b/server.py
@@ -76,7 +76,29 @@ class JadeRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             c.execute('insert or replace into key_value (key,val) values (?,?);',
                       (key,value))
             db.commit()
-                                                        
+
+        # The following conditional is not an obvious or reliable way
+        # to check if the POST request is looking for a 
+        # <module-file>.json, but it seems to work.
+        if 'file' in postvars:
+            # looking for a jade module in ./files
+            fnameList = postvars['file']
+            
+            # if that filename list is empty then 404
+            if len(fnameList) == 0:
+                self.send_response(404, "No modules listed in POST")
+                return
+            
+            # look for the module on disk
+            p = os.path.join("files", fnameList[0])
+            
+            # if the file is there then set response
+            if os.path.exists(p):
+                response = open(p).read()
+            else:
+                self.send_response(404, "Couldn't find module: "+p)
+                return
+            
         self.send_response(200)
         self.send_header("Content-type", 'text/plain')
         self.send_header("Content-Length", str(len(response)))


### PR DESCRIPTION
Jade wasn't loading modules from the files directory when using urls like:

http://localhost:8000/jade_local.html?modules=gates

But, it seems to work now

<hr>

I was thinking of adding a POST_TYPE key to the post object in jade_local.js on line 36

```
// from
if (!shared) args.data = {file: filename };

// to something like
if (!shared) args.data = {file: filename, post_type: "get-module"};
```

So that do_POST in server.py could be more clearly broken up into distinct handlers

```
if post_type == "get-module":
     self.handle_get_module()
...
```
