### PR TITLE
Clarify error message for illegal test values

### DIFF
--- a/test_view.js
+++ b/test_view.js
@@ -425,7 +425,7 @@ jade_defs.test_view = function(jade) {
                 // check for legal test values
                 for (j = 0; j < test.length; j += 1) {
                     if ("01ZLH-".indexOf(test[j]) == -1) {
-                        errors.push('Illegal test value '+test[j]+': '+source[k]);
+                        errors.push('Illegal test value '+test[j]+': '+source[k]+' (must be one of 01ZLH-)');
                         break;
                     }
                 }


### PR DESCRIPTION
This would have saved me a surprising amount of time figuring out that True/False is not the same as High/Low, since the error message is currently rather cryptic.