### PR TITLE
Prevent mouse pointer from switching to text cursor over parts list.

### DIFF
--- a/jade.css
+++ b/jade.css
@@ -146,6 +146,7 @@
 }
 .jade-xparts-list {
     margin-bottom: 3px;
+    cursor: pointer;
     /*
     width: 73px;
     min-width: 73px;


### PR DESCRIPTION
SVG text elements in the parts bin were causing the mouse pointer to
switch to a text cursor, which is a little confusing because that text
isn't editible.