### PR TITLE
Allow immediate server restarts without "socket.error: Address already in use"

### DIFF
--- a/gate_level.js
+++ b/gate_level.js
@@ -243,7 +243,7 @@ jade_defs.gate_level = function(jade) {
         var timing;
         try {
             timing = jade.gatesim.timing_analysis(netlist,diagram.editor.options);
-            timing = $('<pre style="width:600px;height:400px;padding:5px;overflow-y:auto;overflow-x:hidden;"></pre>').append(timing);
+            timing = $('<pre style="width:900px;height:400px;padding:5px;overflow-y:auto;overflow-x:hidden;"></pre>').append(timing);
             timing = timing[0];
 
             timing.resize = function(me,w,h) {

--- a/jade.css
+++ b/jade.css
@@ -2419,3 +2419,14 @@
 .fa-fonticons:before {
   content: "\f280";
 }
+table.timing_details {
+  border-collapse: collapse;
+}
+table.timing_details th, table.timing_details td {
+    border: solid 1px;
+    padding: 2px;
+}
+.important_timing_detail {
+  color:#dc322f;
+  font-weight: bold;
+}

--- a/server.py
+++ b/server.py
@@ -112,7 +112,8 @@ class JadeRequestHandler(BaseHTTPRequestHandler):
     extensions_map.update({
         '': 'application/octet-stream', # Default
     })
-        
+
+socketserver.TCPServer.allow_reuse_address = True
 httpd = socketserver.TCPServer(("",PORT),JadeRequestHandler)
 
 def cleanup():

--- a/server.py
+++ b/server.py
@@ -4,10 +4,12 @@
 try:
     from BaseHTTPServer import BaseHTTPRequestHandler
     import SocketServer as socketserver
+    from cgi import parse_qs
 except:
     # python 3 compatibility
     from http.server import BaseHTTPRequestHandler
     import socketserver
+    from urllib.parse import parse_qs
 
 import mimetypes
 import posixpath
@@ -65,7 +67,7 @@ class JadeRequestHandler(BaseHTTPRequestHandler):
         elif ctype == 'application/x-www-form-urlencoded':
             length = int(self.headers['content-length'])
             content = self.rfile.read(length)
-            for k,v in cgi.parse_qs(content, keep_blank_values=1).items():
+            for k,v in parse_qs(content, keep_blank_values=1).items():
                 # python3 returns everything as bytes, so decode into strings
                 if type(k) == bytes: k = k.decode()
                 postvars[k] = [s.decode() if type(s) == bytes else s for s in v]
@@ -94,7 +96,11 @@ class JadeRequestHandler(BaseHTTPRequestHandler):
         self.send_header("Content-type", 'text/plain')
         self.send_header("Content-Length", str(len(response)))
         self.end_headers()
-        self.wfile.write(response.encode())
+        try:
+            self.wfile.write(response.encode())
+        except AttributeError:
+            # python 3 compatibility
+            self.wfile.write(response)
 
     def guess_type(self, path):
         base, ext = posixpath.splitext(path)


### PR DESCRIPTION
At least on linux, python wasn't letting go of the port binding for up to ~30 seconds after the server stopped.  Maybe other operating systems are dealing with this better.  Something I learned is that:

`allow_reuse_address` is a class member of TCPServer. It has to be set to True before the server is started, because that's when the following call is made

`self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)`

as seen in python's socket library:
https://github.com/python/cpython/blob/693aeacf8851d1e9995073e27e50644a505dc49c/Lib/socketserver.py#L464

Which in turn is what allows the next, (immediate) invocation of server.py to successfully re-bind to port 8000. 